### PR TITLE
feat(core): verify if gaMeasurementId is defined

### DIFF
--- a/src/GoogleAnalytics.svelte
+++ b/src/GoogleAnalytics.svelte
@@ -6,6 +6,11 @@
   export let gaMeasurementId
 
   onMount(() => {
+    if (!gaMeasurementId) {
+      console.error('svelte-google-analytics | gaMeasurementId must be defined')
+      return false
+    }
+    
     loader([
       { type: 'script', url: `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}` }
     ],


### PR DESCRIPTION
Added a simple verification to avoid loading Google Analytics if `gaMeasurementId` is not defined.

Must be updated in the future if supporting multiple IDs.