### PR TITLE
Add configurations prop for configuring Google Property ID:s

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,19 @@ import { GoogleAnalytics } from '@beyonk/svelte-google-analytics'
 
 <GoogleAnalytics properties={[ 'google property id A', ...'google property id X' ]} />
 ```
-Component accepts an `enabled` prop which is set to `true` by default.
+Component accepts two additional properties: `enabled` and `configurations`.
+### The `configurations` property (optional)
+`configurations` props which accepts an object type with configurations for the properties. The key in this object is the id of the property.  
+Example on disabling automatic pageviews for the `id-1` property: 
 
+```svelte
+<GoogleAnalytics 
+    properties={[ 'id-1' ]} 
+    configurations={{ 'id-1': { 'send_page_view': false } }} />
+```
+
+### The `enabled` property (optional)
+The `enabled` prop set to `true` by default.
 Logic can be added here to disable/enable analytics.
 
 ### Page Tracking

--- a/src/GoogleAnalytics.svelte
+++ b/src/GoogleAnalytics.svelte
@@ -4,6 +4,7 @@
   import { gaStore } from './store.js'
 
   export let properties
+  export let configurations = {}
   export let enabled = true
 
   onMount(() => {
@@ -32,7 +33,8 @@
     window.dataLayer = window.dataLayer || []
     gtag('js', new Date())
     properties.forEach(p => {
-      gtag('config', p)
+      const propertyConfig = configurations && configurations[p] || undefined
+      gtag('config', p, propertyConfig)
     })
 
     return gaStore.subscribe(queue => {

--- a/src/GoogleAnalytics.svelte
+++ b/src/GoogleAnalytics.svelte
@@ -33,8 +33,7 @@
     window.dataLayer = window.dataLayer || []
     gtag('js', new Date())
     properties.forEach(p => {
-      const propertyConfig = configurations && configurations[p] || undefined
-      gtag('config', p, propertyConfig)
+      gtag('config', p, configurations[p])
     })
 
     return gaStore.subscribe(queue => {


### PR DESCRIPTION
As discussed in #4.

This is useful in Sapper where only the initial page view is automatically sent on load.
After that each page view must be sent manually using: `ga.addEvent("page_view", { page_path: path });`.

The annoying thing with that is that we must not the send initial page view using `ga.addEvent` because that one is automatic.

```svelte
<script>
import { stores } from "@sapper/app";
import { onMount } from "svelte";
import { GoogleAnalytics, ga } from "@beyonk/svelte-google-analytics";

const { page } = stores();
let initialLoad = true;

onMount(() => {
        return page.subscribe(({ path }) => {
          if (!initialLoad) {
              ga.addEvent("page_view", { page_path: path });
          } else {
              initialLoad = false;
          }
      });
  });
</script>

<GoogleAnalytics properties={['UA-XXXX-X']} />
```

This PR fixes so that we can configure Google Analytics not to send anything automatically and just rely on `ga.addEvent` and remove the `initialLoad` guard:

```svelte
<script>
import { stores } from "@sapper/app";
import { onMount } from "svelte";
import { GoogleAnalytics, ga } from "@beyonk/svelte-google-analytics";

const { page } = stores();

onMount(() => {
        return page.subscribe(({ path }) => {
              ga.addEvent("page_view", { page_path: path });
      });
  });
</script>

<GoogleAnalytics properties={['UA-XXXX-X']} configurations={{'UA-XXXX-X': { 'send_page_view': false }}} />
```

See https://developers.google.com/analytics/devguides/collection/gtagjs#disable_pageview_measurement for reference docs.