### PR TITLE
Fix bug where `undefined` isn’t allow to pass in as gtag config

### DIFF
--- a/src/GoogleAnalytics.svelte
+++ b/src/GoogleAnalytics.svelte
@@ -33,7 +33,7 @@
     window.dataLayer = window.dataLayer || []
     gtag('js', new Date())
     properties.forEach(p => {
-      gtag('config', p, configurations[p])
+      gtag('config', p, configurations[p] || {})
     })
 
     return gaStore.subscribe(queue => {


### PR DESCRIPTION
Sorry @antony, the last PR produced an error if the config was `undefined`, this fixes that.
Now we pass an empty object if no gtag configuration is defined.