### PR TITLE
handle when data is undefined (in `addEvent`)

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -2,7 +2,7 @@
 import { gaStore } from './store.js'
 
 function addEvent (event, data) {
-  if (!data.send_to) { delete data.send_to }
+  if (data && !data.send_to) { delete data.send_to }
   gaStore.update(exisiting => [ ...exisiting, { type: 'event', event, data } ])
 }
 


### PR DESCRIPTION
# The Problem
I think there is one problem but it could be either one.

1. The documentation is not well written and I didn't know `data` parameter in `addEvent` is needed
2. Or the code isn't designed to handle when data is `undefined`

# Code
`addEvent("saw image")` this kind of code with the `data` parameter not specified will result in the following error.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'send_to')
    at Object.addEvent (functions.js:5:13)
    at Event (event.ts:4:5)
    at HTMLInputElement.change_handler_2 (+page.svelte:2266:33)
    at lifecycle.js:181:40
    at Array.forEach (<anonymous>)
    at HTMLInputElement.bubble (lifecycle.js:181:21)
    at HTMLInputElement.change_handler (Input.svelte:40:5)
```

This is because the `data` parameter itself is undefined.

# Solution
## If documentation needs fixing...
If you don't need any kind of data to be sent, you have to put in `{}` to avoid the error.
This is annoying and unnecessary.
I don't think it's the best thing to just enter `{}` if you could enter nothing.

## If the code needs fixing...
I think it's the best thing to check whether data is defined first.
